### PR TITLE
Remove Discord dependancies in the merge script

### DIFF
--- a/tools/merge-upstream-pull-request.sh
+++ b/tools/merge-upstream-pull-request.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source ~/.discordauth
+#source ~/.discordauth
 
 # ~/.discordauth contains:
 # CHANNELID=x
@@ -44,13 +44,13 @@ if ! git remote | grep tgstation > /dev/null; then
    git remote add tgstation https://github.com/tgstation/tgstation.git
 fi
 
-curl -v \
--H "Authorization: Bot $TOKEN" \
--H "User-Agent: myBotThing (http://some.url, v0.1)" \
--H "Content-Type: application/json" \
--X POST \
--d "{\"content\":\"Mirroring [$1] from /tg/ to Hippie\"}" \
-https://discordapp.com/api/channels/$CHANNELID/messages
+#curl -v \
+#-H "Authorization: Bot $TOKEN" \
+#-H "User-Agent: myBotThing (http://some.url, v0.1)" \
+#-H "Content-Type: application/json" \
+#-X POST \
+#-d "{\"content\":\"Mirroring [$1] from /tg/ to Hippie\"}" \
+#https://discordapp.com/api/channels/$CHANNELID/messages
 
 # We need to make sure we are always on a clean master when creating the new branch.
 # So we forcefully reset, clean and then checkout the master branch


### PR DESCRIPTION
Comments out the discord related lines in the merge script. If we decide that we want these later, we can always re-add them in. 

_This will allow the script to run without needing to setup the discord integration._