### PR TITLE
Clear unused z

### DIFF
--- a/_maps/testship.json
+++ b/_maps/testship.json
@@ -3,9 +3,10 @@
     "map_path": "_FTL/map_files/testship",
     "map_file": "testship_transit.dmm",
     "shuttles": {
-	    "cargo": "cargo_box",
-	    "ferry": "ferry_fancy",
-	    "whiteship": "whiteship_box",
-	    "emergency": "emergency_box"
-    }
+	    "cargo": "cargo_box"
+    },
+   "traits": [{"Linkage": "Self"}],
+   "space_ruin_levels": 0,
+   "space_empty_levels": 0,
+   "minetype": "null"
 }


### PR DESCRIPTION
With this config SS dont load bunch of space levels and lava planet.
This all be load later in runtime on FTL jump dependent on sector properties.
